### PR TITLE
Count API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ Keep in mind that stats are still open for anyone that knows that you are using 
 by following the link to https://librecounter.org/example.org/show.
 There is currently no way to make the stats private.
 
+### API
+
+If you want to count a visit but don't want to add an image,
+or just cannot,
+you can use the endpoint `/count`. For instance:
+
+    https://librecounter.org/count?url=http://example.org/mypage
+
+Invoking this URL will count as a visit to the site `example.org`, page `/mypage`.
+You can in fact use whatever programming language to invoke the endpoint,
+even a simple `wget` will do:
+
+```shell
+wget https://librecounter.org/count?url=http://example.org/mypage
+```
+
+Be sure to URL-encode the URL parameter or it will be chopped up as part of the query string.
+
 ## Server Installation
 
 To run your own instance simply download the repo and install all dependencies:
@@ -71,7 +89,7 @@ by day, page, country of origin, browser and OS.
 LibreCounter performs **no tracking**: it does not keep track of what visitors did on your site,
 just counts independent visits to each page.
 IP addresses or user agents are not correlated between page visits.
-In particular, IP addresses are not stored at all.
+In particular, IP addresses and user agents are not stored at all.
 
 ## Help Wanted
 

--- a/lib/core/counter.js
+++ b/lib/core/counter.js
@@ -11,13 +11,15 @@ const detector = new DeviceDetector({
 export class Counter {
 	constructor(ip, headers) {
 		this.day = this.getDay()
-		const {site, page} = this.getReferer(headers)
-		this.site = site
-		this.page = page
 		const {country} = this.lookupGeoip(ip, headers)
 		const userAgent = headers['user-agent']
 		const device = this.getDevice(userAgent)
 		this.stats = {country, ...device}
+		const referer = headers['referer']
+		if (!referer) {
+			return
+		}
+		this.setReferer(referer)
 	}
 
 	getDay() {
@@ -35,16 +37,10 @@ export class Counter {
 		}
 	}
 
-	getReferer(headers) {
-		const referer = headers['referer']
-		if (!referer) {
-			return {}
-		}
+	setReferer(referer) {
 		const url = new URL(referer)
-		return {
-			site: url.host,
-			page: url.pathname,
-		}
+		this.site = url.host
+		this.page = url.pathname
 	}
 
 	lookupGeoip(ip, headers) {

--- a/lib/core/format.js
+++ b/lib/core/format.js
@@ -3,10 +3,16 @@ const maxLabelLength = 30
 
 
 export function encodePage(page) {
+	if (!page) {
+		return null
+	}
 	return page.replaceAll('.', '․').replaceAll('$', '﹩')
 }
 
 export function decodePage(page) {
+	if (!page) {
+		return null
+	}
 	return page.replaceAll('﹩', '$').replaceAll('․', '.')
 }
 

--- a/lib/core/format.js
+++ b/lib/core/format.js
@@ -17,6 +17,9 @@ export function decodePage(page) {
 }
 
 export function shorten(label) {
+	if (!label) {
+		return ''
+	}
 	if (label.length <= maxLabelLength) {
 		return label
 	}

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -16,6 +16,10 @@ export async function readLatestSites() {
 }
 
 export async function storeCounter(counter) {
+	if (!counter.site || !counter.page) {
+		console.log('Missing site or page')
+		return
+	}
 	const update = {total: 1}
 	for (const field in counter.stats) {
 		const value = counter.stats[field]

--- a/lib/server/counter.js
+++ b/lib/server/counter.js
@@ -7,6 +7,7 @@ const logo = await fs.readFile('public/librecounter.svg')
 
 export default async function setup(app) {
 	app.get('/counter.svg', counter)
+	app.get('/count', count)
 }
 
 /**
@@ -15,14 +16,18 @@ export default async function setup(app) {
  * No auth required.
  */
 async function counter(request, reply) {
-	await storeStats(request)
+	const counter = new Counter(request.ip, request.headers)
+	await storeCounter(counter)
 	reply.type('image/svg+xml')
 	reply.header('cache-control', 'no-store;private')
 	return logo
 }
 
-async function storeStats(request) {
+async function count(request) {
 	const counter = new Counter(request.ip, request.headers)
+	console.log(request.query.url)
+	counter.setReferer(request.query.url)
 	await storeCounter(counter)
+	return {ok: true}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librecounter",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Free and open website statistics",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
New endpoint to count a visit `/count?url=...`.

Also in this PR:

* Do not crash without a referer.
* Do not store visits without site or page.

For immediate release as v0.5.0.