### PR TITLE
Counter for unique visitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Free, libre and open website statistics.
 GDPR compliant: no cookies, no tracking done in the browser,
 no IPs stored, no marketing or advertising done (or even possible).
 
-## Website Analysis
+# Website Counter
+
+LibreCounter provides website traffic analysis and statistics.
+
+## Implementation
 
 Simply add the following snippet to your website,
 in all pages that you want analyzed:
@@ -23,10 +27,11 @@ After that, you can visit
 to see your stats,
 and they will be public for all your visitors to see.
 
+That is it! No configuration needed on the server at all.
 You can see an example on [the author's blog](https://pinchito.es/).
 
 Technical details: the `referrerPolicy` is added to make sure that the browser sends the whole page URL to the server,
-otherwise sometimes it only sends the website as `https://example.org/`
+otherwise sometimes it only sends the website (as `https://example.org/`)
 so LibreCounter cannot know which page the user is visiting.
 
 If you don't want visitors to have direct access to your stats
@@ -41,7 +46,23 @@ Keep in mind that stats are still open for anyone that knows that you are using 
 by following the link to https://librecounter.org/example.org/show.
 There is currently no way to make the stats private.
 
-### API
+## Unique Visitors
+
+If you want to count unique visitors to your website instead of page views,
+just add `unique.svg` to your site instead of `counter.svg`:
+
+```html
+<a href="https://librecounter.org/example.org/show">
+<img src="https://librecounter.org/unique.svg" referrerPolicy="unsafe-url">
+</a></textarea>
+```
+
+Again replacing `example.org` with your website domain.
+This makes LibreCounter send the header `cache-control: max-age=1800, private`
+so that the image is cached in your browser across multiple page views,
+for half an hour.
+
+## API
 
 If you want to count a visit but don't want to add an image,
 or just cannot,
@@ -60,6 +81,14 @@ wget https://librecounter.org/count?url=http://example.org/mypage&userAgent=robo
 
 Be sure to URL-encode the URL and user agent parameters or they will be chopped up as part of the query string.
 
+# The Project
+
+It's a super-simple project with 238 lines of code at the time of writing, 2023-10-02.
+It uses the free IP database from Maxmind via
+[`geoip-lite`](https://npmjs.com/package/geoip-lite),
+and the awesome package [`node-device-detector`](https://www.npmjs.com/package/node-device-detector).
+No data is leaked outside as all lookups are done locally.
+
 ## Server Installation
 
 To run your own instance simply download the repo and install all dependencies:
@@ -71,14 +100,6 @@ npm start
 ```
 
 That should do it!
-
-# The Project
-
-It's a super-simple project with 238 lines of code at the time of writing, 2023-10-02.
-It uses the free IP database from Maxmind via
-[`geoip-lite`](https://npmjs.com/package/geoip-lite),
-and the awesome package [`node-device-detector`](https://www.npmjs.com/package/node-device-detector).
-No data is leaked outside as all lookups are done locally.
 
 ## Analytics, Counter or Tracking?
 

--- a/lib/page/common.js
+++ b/lib/page/common.js
@@ -1,0 +1,30 @@
+
+
+export function createHead(title) {
+	return `
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, minimum-scale=1">
+	<title>${title}</title>
+	<link rel="shortcut icon" href="/favicon.png">
+	<link rel="stylesheet" href="/main.css">
+	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+`
+}
+
+export function createFooter() {
+	return `
+	<footer>
+		© 2023 <a href="https://github.com/alexfernandez/librecounter/graphs/contributors">Alex Fernández and contributors</a>.<br />
+		See <a href="https://github.com/alexfernandez/librecounter/">project details</a>.
+	</footer>
+
+</body>
+</html>
+`
+}
+

--- a/lib/page/home.js
+++ b/lib/page/home.js
@@ -1,4 +1,5 @@
 import {getTop10} from '../core/format.js'
+import {createHead, createFooter} from './common.js'
 
 
 export function createHome(latestSites) {
@@ -7,24 +8,15 @@ export function createHome(latestSites) {
 	const barHeight = 30
 	const height = barHeight * (data.length + 2)
 	return `
-<!DOCTYPE html>
-<html>
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, minimum-scale=1">
-	<title>LibreCounter: free, libre counter stats</title>
-	<link rel="shortcut icon" href="/favicon.png">
-	<link rel="stylesheet" href="/main.css">
-	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head>
-<body>
+	${createHead('LibreCounter Stats')}
 	<header>
 		<h1 class="title">
 		<img src="/counter.svg" style="vertical-align:middle"/>
 		LibreCounter
 		</h1>
 		<p>
-		Free, <a href="https://github.com/alexfernandez/librecounter/">libre, open source software</a> to show analytics for your site.
+		Free, <a href="https://github.com/alexfernandez/librecounter/">libre, open source</a>
+		analytics for your site.
 		No installation or configuration required.
 		</p>
 	</header>
@@ -106,13 +98,7 @@ export function createHome(latestSites) {
 		</p>
 	</article>
 
-	<footer>
-		© 2023 Alex Fernández and contributors.<br />
-		Licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GPLv3</a>.
-	</footer>
-
-</body>
-</html>
+${createFooter()}
 `
 }
 

--- a/lib/page/stats.js
+++ b/lib/page/stats.js
@@ -1,19 +1,10 @@
 import {shorten, getTop10} from '../core/format.js'
+import {createHead, createFooter} from './common.js'
 
 
 export function createStatsPage(site, stats) {
 	return `
-<!DOCTYPE html>
-<html>
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, minimum-scale=1">
-	<title>LibreCounter stats for ${site}</title>
-	<link rel="shortcut icon" href="/favicon.png">
-	<link rel="stylesheet" href="/main.css">
-	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-</head>
-<body>
+	${createHead(`LibreCounter Stats for ${site}`)}
 	<header>
 		<h1 class="title">
 		<a href="/"><img src="/counter.svg" style="vertical-align:middle"></a>
@@ -44,12 +35,7 @@ export function createStatsPage(site, stats) {
 			</div>
 		</div>
 	</article>
-	<footer>
-		© 2023 Alex Fernández and contributors. <br />
-		Licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GPLv3</a>.
-	</footer>
-</body>
-</html>
+${createFooter()}
 `
 }
 

--- a/lib/server/counter.js
+++ b/lib/server/counter.js
@@ -3,10 +3,12 @@ import {storeCounter} from '../db/stats.js'
 import {Counter} from '../core/counter.js'
 
 const logo = await fs.readFile('public/librecounter.svg')
+const maxCacheUnique = 1800
 
 
 export default async function setup(app) {
 	app.get('/counter.svg', counter)
+	app.get('/unique.svg', uniqueCounter)
 	app.get('/count', count)
 }
 
@@ -20,6 +22,17 @@ async function counter(request, reply) {
 	await storeCounter(counter)
 	reply.type('image/svg+xml')
 	reply.header('cache-control', 'no-store, private')
+	return logo
+}
+
+/**
+ * Same interface as counter()
+ */
+async function uniqueCounter(request, reply) {
+	const counter = new Counter(request.ip, request.headers)
+	await storeCounter(counter)
+	reply.type('image/svg+xml')
+	reply.header('cache-control', `max-age=${maxCacheUnique}, private`)
 	return logo
 }
 

--- a/lib/server/counter.js
+++ b/lib/server/counter.js
@@ -19,7 +19,7 @@ async function counter(request, reply) {
 	const counter = new Counter(request.ip, request.headers)
 	await storeCounter(counter)
 	reply.type('image/svg+xml')
-	reply.header('cache-control', 'no-store;private')
+	reply.header('cache-control', 'no-store, private')
 	return logo
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librecounter",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Free and open website statistics",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Use `/unique.svg` for counting unique visitors (cached for 30 minutes).

Also in this PR:

* Add link to GitHub in page footer.
* Send cache-control headers with commas, not semicolons.

For immediate release as v0.6.0.