### PR TITLE
API endpoints by site and by page

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ for half an hour.
 
 ## API
 
+The API allows you to count visits and to get stats.
+
+### `/count`
+
 If you want to count a visit but don't want to add an image,
 or just cannot,
 you can use the endpoint `/count`. For instance:
@@ -81,6 +85,17 @@ wget https://librecounter.org/count?url=http://example.org/mypage&userAgent=robo
 ```
 
 Be sure to URL-encode the URL and user agent parameters or they will be chopped up as part of the query string.
+
+### `/[site]/siteStats`
+
+Get stats for your site. Replace `[site]` with the domain for your site like `example.org`.
+For instance:
+
+    https://librecounter.org/example.org/siteStats
+
+Parameters:
+
+* `days`: number of last days to get, default 30.
 
 # The Project
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,19 @@ Parameters:
 
 * `days`: number of last days to get, default 30.
 
+### `/[site]/pageStats`
+
+Get stats for a single page of your site. Replace `[site]` with the domain for your site like `example.org`,
+and add a `page` parameter.
+For instance:
+
+    https://librecounter.org/example.org/pageStats?page=/
+
+Parameters:
+
+* `page`: the page to get, mandatory.
+* `days`: number of last days to get, default 30.
+
 # The Project
 
 It's a super-simple project with 238 lines of code at the time of writing, 2023-10-02.

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,0 +1,6 @@
+import test from '../test/api.js'
+import {close} from '../lib/db/mongo.js'
+
+await test()
+await close()
+

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,6 +1,8 @@
-import test from '../test/api.js'
+import testApi from '../test/api.js'
+import testPages from '../test/pages.js'
 import {close} from '../lib/db/mongo.js'
 
-await test()
+await testApi()
+await testPages()
 await close()
 

--- a/lib/db/mongo.js
+++ b/lib/db/mongo.js
@@ -2,12 +2,13 @@ import {MongoClient} from 'mongodb'
 import dotenv from 'dotenv'
 
 dotenv.config()
+let client
 const db = getDb()
 
 
 function getDb() {
 	const connectionString = process.env['BACKEND_MONGODB_URL']
-	const client = new MongoClient(connectionString, {maxPoolSize: 4})
+	client = new MongoClient(connectionString, {maxPoolSize: 4})
 	return client.db('librecounter')
 }
 
@@ -28,5 +29,9 @@ export async function upsertOne(name, query, value) {
 export async function findAll(name, query) {
 	const collection = db.collection(name)
 	return await collection.find(query).toArray()
+}
+
+export async function close() {
+	await client.close()
 }
 

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,6 +1,6 @@
 
 
-export class DayQuery {
+export class SiteQuery {
 	constructor(site, days) {
 		this.site = site
 		this.days = days
@@ -21,6 +21,19 @@ export class DayQuery {
 			}
 			
 		}
+	}
+}
+
+export class PageQuery extends SiteQuery {
+	constructor(site, page, days) {
+		super(site, days)
+		this.page = page
+	}
+
+	getQuery() {
+		const query = super.getQuery()
+		query.page = this.page
+		return query
 	}
 }
 

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -3,7 +3,7 @@
 export class DayQuery {
 	constructor(site) {
 		this.site = site
-		this.setStartDay(-8)
+		this.setStartDay(-31)
 		this.setEndDay(1)
 	}
 

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,9 +1,10 @@
 
+const defaultStartDay = -31
 
 export class DayQuery {
 	constructor(site) {
 		this.site = site
-		this.setStartDay(-31)
+		this.setStartDay(defaultStartDay)
 		this.setEndDay(1)
 	}
 

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,11 +1,9 @@
 
-const defaultStartDay = -31
 
 export class DayQuery {
-	constructor(site) {
+	constructor(site, days) {
 		this.site = site
-		this.startDay = getDay(defaultStartDay)
-		this.endDay = getDay(1)
+		this.days = days
 	}
 
 	setLastDays(offset) {
@@ -13,11 +11,13 @@ export class DayQuery {
 	}
 
 	getQuery() {
+		const startDay = getDay(-this.days)
+		const endDay = getDay(1)
 		return {
 			site: this.site,
 			day: {
-				$gt: this.startDay,
-				$lt: this.endDay,
+				$gt: startDay,
+				$lt: endDay,
 			}
 			
 		}

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -4,16 +4,12 @@ const defaultStartDay = -31
 export class DayQuery {
 	constructor(site) {
 		this.site = site
-		this.setStartDay(defaultStartDay)
-		this.setEndDay(1)
+		this.startDay = getDay(defaultStartDay)
+		this.endDay = getDay(1)
 	}
 
-	setStartDay(diff) {
-		this.startDay = getDay(diff)
-	}
-
-	setEndDay(diff) {
-		this.endDay = getDay(diff)
+	setLastDays(offset) {
+		this.startDay = getDay(-offset)
 	}
 
 	getQuery() {

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -1,0 +1,37 @@
+
+
+export class DayQuery {
+	constructor(site) {
+		this.site = site
+		this.setStartDay(-8)
+		this.setEndDay(1)
+	}
+
+	setStartDay(diff) {
+		this.startDay = getDay(diff)
+	}
+
+	setEndDay(diff) {
+		this.endDay = getDay(diff)
+	}
+
+	getQuery() {
+		return {
+			site: this.site,
+			day: {
+				$gt: this.startDay,
+				$lt: this.endDay,
+			}
+			
+		}
+	}
+}
+
+export function getDay(diff) {
+	const date = new Date()
+	if (diff) {
+		date.setDate(date.getDate() + diff)
+	}
+	return date.toISOString().substring(0, 10)
+}
+

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -38,6 +38,10 @@ export async function storeCounter(counter) {
 
 export async function readSiteStats(query) {
 	const array = await findAll('days', query.getQuery())
+	return buildStats(array)
+}
+
+function buildStats(array) {
 	const result = {total: 0, byDay: []}
 	for (const element of array) {
 		const day = element.day
@@ -65,6 +69,11 @@ export async function readSiteStats(query) {
 		}
 	}
 	return result
+}
+
+export async function readPageStats(query) {
+	const array = await findAll('pages', query.getQuery())
+	return buildStats(array)
 }
 
 function readSectionKey(field) {

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -41,7 +41,7 @@ export async function readSiteStats(site) {
 	const result = {total: 0, byDay: []}
 	for (const element of array) {
 		const day = element.day
-		result.byDay.push({key: day, value: element.total})
+		result.byDay.push({day, value: element.total})
 		result.total += element.total
 		for (const field in element) {
 			const [section, key] = readSectionKey(field)
@@ -74,9 +74,10 @@ function readSectionKey(field) {
 	}
 	const key = parts[0]
 	const value = parts.slice(1).join(':')
+	const name = 'by' + key.substring(0, 1).toUpperCase() + key.substring(1)
 	if (key != 'page') {
-		return [key, value]
+		return [name, value]
 	}
-	return [key, decodePage(value)]
+	return [name, decodePage(value)]
 }
 

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -36,8 +36,8 @@ export async function storeCounter(counter) {
 	await upsertOne('pages', {site: counter.site, day: counter.day, page: counter.page}, {$inc: update})
 }
 
-export async function readSiteStats(site) {
-	const array = await findAll('days', {site})
+export async function readSiteStats(query) {
+	const array = await findAll('days', query.getQuery())
 	const result = {total: 0, byDay: []}
 	for (const element of array) {
 		const day = element.day

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -1,4 +1,5 @@
 import {createIndex, findAll, upsertOne} from './mongo.js'
+import {getDay} from './query.js'
 import {encodePage, decodePage} from '../core/format.js'
 
 
@@ -10,7 +11,7 @@ async function init() {
 }
 
 export async function readLatestSites() {
-	const day = new Date().toISOString().substring(0, 10)
+	const day = getDay()
 	const all = await findAll('days', {day}, {site: 1, total: 1})
 	return all.map(stats => ({key: stats.site, value: stats.total}))
 }

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -6,13 +6,13 @@ import {encodePage, decodePage} from '../core/format.js'
 await init()
 
 async function init() {
-	await createIndex('days', {site: 1, day: 1})
+	await createIndex('sites', {site: 1, day: 1})
 	await createIndex('pages', {site: 1, day: 1, page: 1})
 }
 
 export async function readLatestSites() {
 	const day = getDay()
-	const all = await findAll('days', {day}, {site: 1, total: 1})
+	const all = await findAll('sites', {day}, {site: 1, total: 1})
 	return all.map(stats => ({key: stats.site, value: stats.total}))
 }
 
@@ -32,12 +32,12 @@ export async function storeCounter(counter) {
 	const page = encodePage(counter.page)
 	const pageKey = `page:${page}`
 	const updateWithPage = {...update, [pageKey]: 1}
-	await upsertOne('days', {site: counter.site, day: counter.day}, {$inc: updateWithPage})
+	await upsertOne('sites', {site: counter.site, day: counter.day}, {$inc: updateWithPage})
 	await upsertOne('pages', {site: counter.site, day: counter.day, page: counter.page}, {$inc: update})
 }
 
 export async function readSiteStats(query) {
-	const array = await findAll('days', query.getQuery())
+	const array = await findAll('sites', query.getQuery())
 	return buildStats(array)
 }
 

--- a/lib/page/common.js
+++ b/lib/page/common.js
@@ -1,8 +1,7 @@
 
 
 export function createHead(title) {
-	return `
-<!DOCTYPE html>
+	return `<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="utf-8" />
@@ -24,7 +23,6 @@ export function createFooter() {
 	</footer>
 
 </body>
-</html>
-`
+</html>`
 }
 

--- a/lib/page/home.js
+++ b/lib/page/home.js
@@ -6,8 +6,7 @@ export function createHome(latestSites) {
 	const {labels, data} = getTop10(latestSites)
 	const barHeight = 30
 	const height = barHeight * (data.length + 2)
-	return `
-	${createHead('LibreCounter Stats')}
+	return `${createHead('LibreCounter Stats')}
 	<header>
 		<h1 class="title">
 		<img src="/counter.svg" style="vertical-align:middle"/>
@@ -96,9 +95,7 @@ export function createHome(latestSites) {
 		Since no cookies are used you don't need to add a disclaimer to your site.
 		</p>
 	</article>
-
-${createFooter()}
-`
+${createFooter()}`
 }
 
 function createRows(labels, data) {

--- a/lib/page/stats.js
+++ b/lib/page/stats.js
@@ -4,8 +4,7 @@ import {createHead, createFooter} from './common.js'
 
 export function createStatsPage(query, stats) {
 	const days = query.days == 1 ? 'day' : `${query.days} days`
-	return `
-	${createHead(`LibreCounter Stats for ${query.site}`)}
+	return `${createHead(`LibreCounter Stats for ${query.site}`)}
 	<header>
 		<h1 class="title">
 		<a href="/" class="imageLink"><img src="/counter.svg" style="vertical-align:middle"></a>
@@ -39,8 +38,7 @@ export function createStatsPage(query, stats) {
 			</div>
 		</div>
 	</article>
-${createFooter()}
-`
+${createFooter()}`
 }
 
 function createTimeSeries(stats) {

--- a/lib/page/stats.js
+++ b/lib/page/stats.js
@@ -1,4 +1,4 @@
-import {shorten, getTop10} from '../core/format.js'
+import {getTop10} from '../core/format.js'
 import {createHead, createFooter} from './common.js'
 
 
@@ -19,19 +19,19 @@ export function createStatsPage(site, stats) {
 		<div class="graphs">
 			<div class="graph">
 				<h2>Stats per page</h2>
-				${createHorizontalChart(stats.page, 'pages', '#3300ff')}
+				${createHorizontalChart(stats.byPage, 'pages', '#3300ff')}
 			</div>
 			<div class="graph">
 				<h2>Stats per country</h2>
-				${createHorizontalChart(stats.country, 'countries', '#cc6666')}
+				${createHorizontalChart(stats.byCountry, 'countries', '#cc6666')}
 			</div>
 			<div class="graph">
 				<h2>Stats per browser</h2>
-				${createHorizontalChart(stats.browser, 'browsers', '#66cc66')}
+				${createHorizontalChart(stats.byBrowser, 'browsers', '#66cc66')}
 			</div>
 			<div class="graph">
 				<h2>Stats per OS</h2>
-				${createHorizontalChart(stats.os, 'os', '#cccc66')}
+				${createHorizontalChart(stats.byOs, 'os', '#cccc66')}
 			</div>
 		</div>
 	</article>
@@ -44,8 +44,8 @@ function createTimeSeries(stats) {
 		return 'No stats yet'
 	}
 	const canvasId = 'chart-time'
-	stats.sort((a, b) => a.key.localeCompare(b.key))
-	const labels = stats.map(site => site.key).map(shorten)
+	stats.sort((a, b) => a.day.localeCompare(b.day))
+	const labels = stats.map(site => site.day)
 	const data = stats.map(site => site.value)
 	return `
 	<div class="canvas">

--- a/lib/page/stats.js
+++ b/lib/page/stats.js
@@ -7,7 +7,7 @@ export function createStatsPage(site, stats) {
 	${createHead(`LibreCounter Stats for ${site}`)}
 	<header>
 		<h1 class="title">
-		<a href="/"><img src="/counter.svg" style="vertical-align:middle"></a>
+		<a href="/" class="imageLink"><img src="/counter.svg" style="vertical-align:middle"></a>
 		LibreCounter — ${site}
 		</h1>
 	</header>

--- a/lib/page/stats.js
+++ b/lib/page/stats.js
@@ -12,6 +12,9 @@ export function createStatsPage(site, stats) {
 		</h1>
 	</header>
 	<article>
+		<p>
+		Showing data for the last 30 days.
+		</p>
 		<div class="graph">
 			<h2>Stats per day</h2>
 			${createTimeSeries(stats.byDay)}

--- a/lib/page/stats.js
+++ b/lib/page/stats.js
@@ -2,18 +2,19 @@ import {getTop10} from '../core/format.js'
 import {createHead, createFooter} from './common.js'
 
 
-export function createStatsPage(site, stats) {
+export function createStatsPage(query, stats) {
+	const days = query.days == 1 ? 'day' : `${query.days} days`
 	return `
-	${createHead(`LibreCounter Stats for ${site}`)}
+	${createHead(`LibreCounter Stats for ${query.site}`)}
 	<header>
 		<h1 class="title">
 		<a href="/" class="imageLink"><img src="/counter.svg" style="vertical-align:middle"></a>
-		LibreCounter — ${site}
+		LibreCounter — ${query.site}
 		</h1>
 	</header>
 	<article>
 		<p>
-		Showing data for the last 30 days.
+		Showing data for the last ${days}.
 		</p>
 		<div class="graph">
 			<h2>Stats per day</h2>
@@ -48,8 +49,8 @@ function createTimeSeries(stats) {
 	}
 	const canvasId = 'chart-time'
 	stats.sort((a, b) => a.day.localeCompare(b.day))
-	const labels = stats.map(site => site.day)
-	const data = stats.map(site => site.value)
+	const labels = stats.map(dayStats => dayStats.day)
+	const data = stats.map(dayStats => dayStats.value)
 	return `
 	<div class="canvas">
 		<canvas id="${canvasId}"></canvas>

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -2,6 +2,9 @@ import {DayQuery} from '../db/query.js'
 import {readSiteStats} from '../db/stats.js'
 import {createStatsPage} from '../page/stats.js'
 
+const defaultDays = 30
+
+
 export default async function setup(app) {
 	app.get('/:site/siteStats', fetchStats)
 	app.get('/:site/pageStats', fetchStats)
@@ -11,15 +14,13 @@ export default async function setup(app) {
 /**
  * Request params: site.
  * Query params:
- *	- days: show data only for the latest days.
+ *	- days: show data only for the latest days, default 30.
  * Response: {ok}.
  * No auth required.
  */
 async function fetchStats(request) {
-	const query = new DayQuery(request.params.site)
-	if (request.query.days) {
-		query.setLastDays(request.query.days)
-	}
+	const days = request.query.days || defaultDays
+	const query = new DayQuery(request.params.site, days)
 	return await readSiteStats(query)
 }
 

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -3,7 +3,8 @@ import {readSiteStats} from '../db/stats.js'
 import {createStatsPage} from '../page/stats.js'
 
 export default async function setup(app) {
-	app.get('/:site/stats', fetchStats)
+	app.get('/:site/siteStats', fetchStats)
+	app.get('/:site/pageStats', fetchStats)
 	app.get('/:site/show', show)
 }
 

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -30,9 +30,10 @@ async function fetchStats(request) {
  * No auth required.
  */
 async function show(request, reply) {
-	reply.type('text/html')
-	const query = new DayQuery(request.params.site)
+	const days = request.query.days || defaultDays
+	const query = new DayQuery(request.params.site, days)
 	const stats = await readSiteStats(query)
-	return createStatsPage(request.params.site, stats)
+	reply.type('text/html')
+	return createStatsPage(query, stats)
 }
 

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -1,13 +1,13 @@
-import {DayQuery} from '../db/query.js'
-import {readSiteStats} from '../db/stats.js'
+import {SiteQuery, PageQuery} from '../db/query.js'
+import {readSiteStats, readPageStats} from '../db/stats.js'
 import {createStatsPage} from '../page/stats.js'
 
 const defaultDays = 30
 
 
 export default async function setup(app) {
-	app.get('/:site/siteStats', fetchStats)
-	app.get('/:site/pageStats', fetchStats)
+	app.get('/:site/siteStats', fetchSiteStats)
+	app.get('/:site/pageStats', fetchPageStats)
 	app.get('/:site/show', show)
 }
 
@@ -18,10 +18,24 @@ export default async function setup(app) {
  * Response: {ok}.
  * No auth required.
  */
-async function fetchStats(request) {
+async function fetchSiteStats(request) {
 	const days = request.query.days || defaultDays
-	const query = new DayQuery(request.params.site, days)
+	const query = new SiteQuery(request.params.site, days)
 	return await readSiteStats(query)
+}
+
+/**
+ * Request params: site.
+ * Query params:
+ *	- page: the page to show.
+ *	- days: show data only for the latest days, default 30.
+ * Response: {ok}.
+ * No auth required.
+ */
+async function fetchPageStats(request) {
+	const days = request.query.days || defaultDays
+	const query = new PageQuery(request.params.site, days)
+	return await readPageStats(query)
 }
 
 /**
@@ -31,7 +45,7 @@ async function fetchStats(request) {
  */
 async function show(request, reply) {
 	const days = request.query.days || defaultDays
-	const query = new DayQuery(request.params.site, days)
+	const query = new SiteQuery(request.params.site, days)
 	const stats = await readSiteStats(query)
 	reply.type('text/html')
 	return createStatsPage(query, stats)

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -7,7 +7,7 @@ export default async function setup(app) {
 }
 
 /**
- * Request: site.
+ * Request params: site.
  * Response: {ok}.
  * No auth required.
  */

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -17,7 +17,6 @@ async function stats(request) {
 }
 
 async function show(request, reply) {
-
 	reply.type('text/html')
 	const site = request.params.site
 	const stats = await readSiteStats(site)

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -1,3 +1,4 @@
+import {DayQuery} from '../db/query.js'
 import {readSiteStats} from '../db/stats.js'
 import {createStatsPage} from '../page/stats.js'
 
@@ -12,14 +13,19 @@ export default async function setup(app) {
  * No auth required.
  */
 async function stats(request) {
-	const site = request.params.site
-	return await readSiteStats(site)
+	const query = new DayQuery(request.params.site)
+	return await readSiteStats(query)
 }
 
+/**
+ * Request params: site.
+ * Response: complete web page.
+ * No auth required.
+ */
 async function show(request, reply) {
 	reply.type('text/html')
-	const site = request.params.site
-	const stats = await readSiteStats(site)
-	return createStatsPage(site, stats)
+	const query = new DayQuery(request.params.site)
+	const stats = await readSiteStats(query)
+	return createStatsPage(request.params.site, stats)
 }
 

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -3,16 +3,17 @@ import {readSiteStats} from '../db/stats.js'
 import {createStatsPage} from '../page/stats.js'
 
 export default async function setup(app) {
-	app.get('/:site/stats', stats)
+	app.get('/:site/stats', fetchStats)
 	app.get('/:site/show', show)
 }
 
 /**
  * Request params: site.
+ * Query params:
  * Response: {ok}.
  * No auth required.
  */
-async function stats(request) {
+async function fetchStats(request) {
 	const query = new DayQuery(request.params.site)
 	return await readSiteStats(query)
 }

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -10,11 +10,15 @@ export default async function setup(app) {
 /**
  * Request params: site.
  * Query params:
+ *	- days: show data only for the latest days.
  * Response: {ok}.
  * No auth required.
  */
 async function fetchStats(request) {
 	const query = new DayQuery(request.params.site)
+	if (request.query.days) {
+		query.setLastDays(request.query.days)
+	}
 	return await readSiteStats(query)
 }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "supervisor bin/start.js",
     "start": "node bin/start.js",
-    "test": "tap --reporter=list"
+    "test": "node bin/test.js"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/alexfernandez/librecounter#readme",
   "devDependencies": {
+    "pino-pretty": "^10.2.3",
     "supervisor": "^0.12.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librecounter",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Free and open website statistics",
   "type": "module",
   "main": "index.js",

--- a/public/main.css
+++ b/public/main.css
@@ -67,6 +67,10 @@ a:visited {
 	border-bottom: dashed 1px #004488;
 }
 
+.imageLink {
+	border: none;
+}
+
 @media screen and (max-width: 1150px) {
 	.graphs {
 		grid-template-columns: 1fr;

--- a/test/api.js
+++ b/test/api.js
@@ -1,4 +1,5 @@
 import {app} from './setup.js'
+import {getDay} from '../lib/db/query.js'
 
 
 const site = 'test.com'
@@ -10,8 +11,9 @@ async function testCounter() {
 		url: `/count?url=http://${site}${path}&userAgent=${userAgent}`,
 		method: 'GET',
 	})
-	console.log(response)
 	console.assert(response.statusCode == 200, 'could not count')
+	const result = response.json()
+	console.assert(result.ok, 'did not count')
 }
 
 async function testStats() {
@@ -20,8 +22,16 @@ async function testStats() {
 		method: 'GET',
 		headers: {'user-agent': 'testbot/1.0'},
 	})
-	console.log(response)
 	console.assert(response.statusCode == 200, 'could not stats')
+	const result = response.json()
+	console.assert(result.byDay, 'has no days')
+	console.assert(Array.isArray(result.byDay), 'byDay is not an array')
+	const day = getDay()
+	const found = result.byDay.filter(dayStats => dayStats.key == day)
+	console.assert(found.length == 1, 'no data today')
+	console.assert(found[0].value > 0, 'no value today')
+	console.assert(result.page, 'has no pages')
+	console.assert(result.page[path], 'has no path')
 }
 
 export default async function test() {

--- a/test/api.js
+++ b/test/api.js
@@ -1,0 +1,31 @@
+import {app} from './setup.js'
+
+
+const site = 'test.com'
+const path = '/mypage.fi'
+const userAgent = 'testbot/1.0'
+
+async function testCounter() {
+	const response = await app.inject({
+		url: `/count?url=http://${site}${path}&userAgent=${userAgent}`,
+		method: 'GET',
+	})
+	console.log(response)
+	console.assert(response.statusCode == 200, 'could not count')
+}
+
+async function testStats() {
+	const response = await app.inject({
+		url: `/${site}/stats`,
+		method: 'GET',
+		headers: {'user-agent': 'testbot/1.0'},
+	})
+	console.log(response)
+	console.assert(response.statusCode == 200, 'could not stats')
+}
+
+export default async function test() {
+	await testCounter()
+	await testStats()
+}
+

--- a/test/api.js
+++ b/test/api.js
@@ -18,7 +18,7 @@ async function testCounter() {
 
 async function testStats() {
 	const response = await app.inject({
-		url: `/${site}/stats`,
+		url: `/${site}/siteStats`,
 		method: 'GET',
 		headers: {'user-agent': 'testbot/1.0'},
 	})
@@ -36,7 +36,7 @@ async function testStats() {
 
 async function testLastDays() {
 	const response = await app.inject({
-		url: `/${site}/stats?days=1`,
+		url: `/${site}/siteStats?days=1`,
 		method: 'GET',
 		headers: {'user-agent': 'testbot/1.0'},
 	})

--- a/test/api.js
+++ b/test/api.js
@@ -7,8 +7,13 @@ const path = '/mypage.fi'
 const userAgent = 'testbot/1.0'
 
 async function testCounter() {
+	await testPage(path)
+	await testPage('/')
+}
+
+async function testPage(page) {
 	const response = await app.inject({
-		url: `/count?url=http://${site}${path}&userAgent=${userAgent}`,
+		url: `/count?url=http://${site}${page}&userAgent=${userAgent}`,
 		method: 'GET',
 	})
 	console.assert(response.statusCode == 200, 'could not count')
@@ -16,7 +21,7 @@ async function testCounter() {
 	console.assert(result.ok, 'did not count')
 }
 
-async function testStats() {
+async function testSiteStats() {
 	const response = await app.inject({
 		url: `/${site}/siteStats`,
 		method: 'GET',
@@ -50,9 +55,22 @@ async function testLastDays() {
 	console.assert(dayStats.value > 0, 'no value today')
 }
 
+async function testPageStats() {
+	const response = await app.inject({
+		url: `/${site}/pageStats?page=${path}`,
+		method: 'GET',
+		headers: {'user-agent': 'testbot/1.0'},
+	})
+	console.assert(response.statusCode == 200, 'could not get page stats')
+	const result = response.json()
+	console.assert(result.byDay, 'has no days')
+	console.assert(!result.byPage, 'should have no page')
+}
+
 export default async function test() {
 	await testCounter()
-	await testStats()
+	await testSiteStats()
+	await testPageStats()
 	await testLastDays()
 }
 

--- a/test/api.js
+++ b/test/api.js
@@ -34,8 +34,25 @@ async function testStats() {
 	console.assert(result.byPage[path], 'has no path')
 }
 
+async function testLastDays() {
+	const response = await app.inject({
+		url: `/${site}/stats?days=1`,
+		method: 'GET',
+		headers: {'user-agent': 'testbot/1.0'},
+	})
+	console.assert(response.statusCode == 200, 'could not stats')
+	const result = response.json()
+	console.assert(result.byDay, 'has no days')
+	console.assert(result.byDay.length == 1, 'should only have one day')
+	const dayStats = result.byDay[0]
+	const day = getDay()
+	console.assert(dayStats.day == day, 'should only have today')
+	console.assert(dayStats.value > 0, 'no value today')
+}
+
 export default async function test() {
 	await testCounter()
 	await testStats()
+	await testLastDays()
 }
 

--- a/test/api.js
+++ b/test/api.js
@@ -7,11 +7,11 @@ const path = '/mypage.fi'
 const userAgent = 'testbot/1.0'
 
 async function testCounter() {
-	await testPage(path)
-	await testPage('/')
+	await testCountPage(path)
+	await testCountPage('/')
 }
 
-async function testPage(page) {
+async function testCountPage(page) {
 	const response = await app.inject({
 		url: `/count?url=http://${site}${page}&userAgent=${userAgent}`,
 		method: 'GET',

--- a/test/api.js
+++ b/test/api.js
@@ -27,11 +27,11 @@ async function testStats() {
 	console.assert(result.byDay, 'has no days')
 	console.assert(Array.isArray(result.byDay), 'byDay is not an array')
 	const day = getDay()
-	const found = result.byDay.filter(dayStats => dayStats.key == day)
+	const found = result.byDay.filter(dayStats => dayStats.day == day)
 	console.assert(found.length == 1, 'no data today')
 	console.assert(found[0].value > 0, 'no value today')
-	console.assert(result.page, 'has no pages')
-	console.assert(result.page[path], 'has no path')
+	console.assert(result.byPage, 'has no pages')
+	console.assert(result.byPage[path], 'has no path')
 }
 
 export default async function test() {

--- a/test/pages.js
+++ b/test/pages.js
@@ -1,0 +1,45 @@
+import {app} from './setup.js'
+
+
+const site = 'test.com'
+const userAgent = 'testbot/1.0'
+
+async function testHomePage() {
+	const response = await app.inject({
+		url: `/`,
+		method: 'GET',
+		headers: {'user-agent': userAgent},
+	})
+	console.assert(response.statusCode == 200, 'could not home')
+	console.assert(response.payload.includes('LibreCounter Stats'), 'did not home')
+}
+
+async function testStatsPage() {
+	const response = await app.inject({
+		url: `/${site}/show`,
+		method: 'GET',
+		headers: {'user-agent': userAgent},
+	})
+	console.assert(response.statusCode == 200, 'could not stats')
+	console.assert(response.payload.includes(site), 'did not stats')
+}
+
+async function testCounterSvg() {
+	const response = await app.inject({
+		url: `/counter.svg`,
+		method: 'GET',
+		headers: {
+			'user-agent': userAgent,
+			referer: `https://${site}/myPage.fo`
+		},
+	})
+	console.assert(response.statusCode == 200, 'could not counter')
+	console.assert(response.payload.includes('<svg'), 'did not counter')
+}
+
+export default async function test() {
+	await testHomePage()
+	await testStatsPage()
+	await testCounterSvg()
+}
+

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,7 @@
+import setup from '../lib/server/setup.js'
+import Fastify from 'fastify'
+
+
+export const app = Fastify({logger: {level: 'error'}, transport: {target: 'pino-pretty'}})
+setup(app)
+


### PR DESCRIPTION
Add API endpoints by site and by page:

* `/[site]/siteStats` provide stats for the site.
* `/[site]/pageStats?page=[page]` provide stats for the site.

Also in this PR:

* Add parameter `days` to show only the last days, e.g.: `/[site]/show?days=1`.
* Add integrations tests for API (look at our child all grown up!).
* Do not underline image links.

Incompatible changes:

* Collection `days` is renamed to `sites`.
* Endpoint `/stats` renamed to `/siteStats`. JSON format also changed: `page` attribute is now `byPage` and so on.

To be released as v0.7.0.
Must run this command in `mongosh` right after deployment:

```
db.days.renameCollection('sites', true)
```