### PR TITLE
Hide sensitive domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ npm start
 
 That should do it!
 
+### Server Configuration
+
+You can create a file `.env` and add it at the root of the project,
+with the following variables in the usual [dotenv format](https://www.npmjs.com/package/dotenv):
+
+* `BACKEND_MONGODB_URL`: URL to connect to MongoDB including password,
+default value: `mongodb://localhost:27017/librecounter`.
+* `BACKEND_DOMAIN_HIDELIST`: comma-separated list of domains to hide:
+not store or show stats at all. Default value: empty string.
+
 ## Analytics, Counter or Tracking?
 
 LibreCounter is a small step beyond the old website counters

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ for instance with this snippet:
 Keep in mind that stats are still open for anyone that knows that you are using it,
 by following the link to https://librecounter.org/example.org/show.
 There is currently no way to make the stats private.
+If you want to hide stats for a sensitive domain
+(like an integration domain you don't want to show),
+please let [the author](https://github.com/alexfernandez/)
+know to add it to the hide list so that stats are not stored at all.
 
 ## Unique Visitors
 

--- a/lib/db/counter.js
+++ b/lib/db/counter.js
@@ -1,0 +1,24 @@
+import {upsertOne} from './mongo.js'
+import {encodePage} from '../core/format.js'
+
+
+export async function storeCounter(counter) {
+	if (!counter.site || !counter.page) {
+		console.log('Missing site or page')
+		return
+	}
+	const update = {total: 1}
+	for (const field in counter.stats) {
+		const value = counter.stats[field]
+		if (value) {
+			const key = `${field}:${value}`
+			update[key] = 1
+		}
+	}
+	const page = encodePage(counter.page)
+	const pageKey = `page:${page}`
+	const updateWithPage = {...update, [pageKey]: 1}
+	await upsertOne('sites', {site: counter.site, day: counter.day}, {$inc: updateWithPage})
+	await upsertOne('pages', {site: counter.site, day: counter.day, page: counter.page}, {$inc: update})
+}
+

--- a/lib/db/counter.js
+++ b/lib/db/counter.js
@@ -1,9 +1,6 @@
-import {upsertOne} from './mongo.js'
+import {upsertOne, domainsToHide} from './mongo.js'
 import {encodePage} from '../core/format.js'
 
-
-const domainHideList = process.env['BACKEND_DOMAIN_HIDELIST']
-const domainsToHide = domainHideList.split(',')
 
 export async function storeCounter(counter) {
 	if (!counter.site || !counter.page) {

--- a/lib/db/counter.js
+++ b/lib/db/counter.js
@@ -2,9 +2,16 @@ import {upsertOne} from './mongo.js'
 import {encodePage} from '../core/format.js'
 
 
+const domainHideList = process.env['BACKEND_DOMAIN_HIDELIST']
+const domainsToHide = domainHideList.split(',')
+
 export async function storeCounter(counter) {
 	if (!counter.site || !counter.page) {
 		console.log('Missing site or page')
+		return
+	}
+	if (domainsToHide.includes(counter.site)) {
+		console.log(`Domain ${counter.site} is hidden`)
 		return
 	}
 	const update = {total: 1}

--- a/lib/db/mongo.js
+++ b/lib/db/mongo.js
@@ -4,12 +4,12 @@ import dotenv from 'dotenv'
 dotenv.config()
 let client
 const db = getDb()
-const domainHideList = process.env['BACKEND_DOMAIN_HIDELIST']
+const domainHideList = process.env['BACKEND_DOMAIN_HIDELIST'] || ''
 export const domainsToHide = domainHideList.split(',')
 
 
 function getDb() {
-	const connectionString = process.env['BACKEND_MONGODB_URL']
+	const connectionString = process.env['BACKEND_MONGODB_URL'] || 'mongodb://localhost:27017/librecounter'
 	client = new MongoClient(connectionString, {maxPoolSize: 4})
 	return client.db('librecounter')
 }

--- a/lib/db/mongo.js
+++ b/lib/db/mongo.js
@@ -4,6 +4,8 @@ import dotenv from 'dotenv'
 dotenv.config()
 let client
 const db = getDb()
+const domainHideList = process.env['BACKEND_DOMAIN_HIDELIST']
+export const domainsToHide = domainHideList.split(',')
 
 
 function getDb() {

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -1,6 +1,6 @@
-import {createIndex, findAll, upsertOne} from './mongo.js'
+import {createIndex, findAll} from './mongo.js'
 import {getDay} from './query.js'
-import {encodePage, decodePage} from '../core/format.js'
+import {decodePage} from '../core/format.js'
 
 
 await init()
@@ -14,26 +14,6 @@ export async function readLatestSites() {
 	const day = getDay()
 	const all = await findAll('sites', {day}, {site: 1, total: 1})
 	return all.map(stats => ({key: stats.site, value: stats.total}))
-}
-
-export async function storeCounter(counter) {
-	if (!counter.site || !counter.page) {
-		console.log('Missing site or page')
-		return
-	}
-	const update = {total: 1}
-	for (const field in counter.stats) {
-		const value = counter.stats[field]
-		if (value) {
-			const key = `${field}:${value}`
-			update[key] = 1
-		}
-	}
-	const page = encodePage(counter.page)
-	const pageKey = `page:${page}`
-	const updateWithPage = {...update, [pageKey]: 1}
-	await upsertOne('sites', {site: counter.site, day: counter.day}, {$inc: updateWithPage})
-	await upsertOne('pages', {site: counter.site, day: counter.day, page: counter.page}, {$inc: update})
 }
 
 export async function readSiteStats(query) {

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -1,4 +1,4 @@
-import {createIndex, findAll} from './mongo.js'
+import {createIndex, findAll, domainsToHide} from './mongo.js'
 import {getDay} from './query.js'
 import {decodePage} from '../core/format.js'
 
@@ -13,10 +13,14 @@ async function init() {
 export async function readLatestSites() {
 	const day = getDay()
 	const all = await findAll('sites', {day}, {site: 1, total: 1})
-	return all.map(stats => ({key: stats.site, value: stats.total}))
+	const filtered = all.filter(stats => !domainsToHide.includes(stats.site))
+	return filtered.map(stats => ({key: stats.site, value: stats.total}))
 }
 
 export async function readSiteStats(query) {
+	if (domainsToHide.includes(query.site)) {
+		return {total: 0}
+	}
 	const array = await findAll('sites', query.getQuery())
 	return buildStats(array)
 }
@@ -52,6 +56,9 @@ function buildStats(array) {
 }
 
 export async function readPageStats(query) {
+	if (domainsToHide.includes(query.site)) {
+		return {total: 0}
+	}
 	const array = await findAll('pages', query.getQuery())
 	return buildStats(array)
 }

--- a/lib/page/stats.js
+++ b/lib/page/stats.js
@@ -42,7 +42,7 @@ ${createFooter()}`
 }
 
 function createTimeSeries(stats) {
-	if (!stats.length) {
+	if (!stats?.length) {
 		return 'No stats yet'
 	}
 	const canvasId = 'chart-time'

--- a/lib/server/counter.js
+++ b/lib/server/counter.js
@@ -1,5 +1,5 @@
 import {promises as fs} from 'fs'
-import {storeCounter} from '../db/stats.js'
+import {storeCounter} from '../db/counter.js'
 import {Counter} from '../core/counter.js'
 
 const logo = await fs.readFile('public/librecounter.svg')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librecounter",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Free and open website statistics",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
Add a hide list in env variable `BACKEND_DOMAIN_HIDELIST` so that stats are not collected nor shown.

Also in this PR:

* Add default value for env variable with MongoDB connection.
* Document server configuration.

For immediate release as v0.9.0.