### PR TITLE
Cache stats for a second

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,7 @@ Parameters:
 
 ### `/[site]/pageStats`
 
-Get stats for a single page of your site. Replace `[site]` with the domain for your site like `example.org`,
-and add a `page` parameter.
-For instance:
-
-    https://librecounter.org/example.org/pageStats?page=/
-
-Parameters:
-
-* `page`: the page to get, mandatory.
-* `days`: number of last days to get, default 30.
+Deprecated and removed in v2.0: this API call was broken.
 
 ## The Project
 

--- a/lib/core/cache.js
+++ b/lib/core/cache.js
@@ -1,0 +1,36 @@
+
+
+const cache = new Map()
+const timeoutMs = 1000
+
+class CacheEntry {
+	constructor(value) {
+		this.value = value
+		this.expiration = Date.now() + timeoutMs
+	}
+
+	isExpired() {
+		const now = Date.now()
+		return (now > this.expiration)
+	}
+}
+
+export function getCached(name, params) {
+	const key = buildKey(name, params)
+	const entry = cache.get(key)
+	if (!entry || entry.isExpired()) {
+		return null
+	}
+	return entry.value
+}
+
+export function setCached(name, params, value) {
+	const key = buildKey(name, params)
+	const entry = new CacheEntry(value)
+	cache.set(key, entry)
+}
+
+function buildKey(name, params) {
+	return `${name}-${JSON.stringify(params)}`
+}
+

--- a/lib/db/mongo.js
+++ b/lib/db/mongo.js
@@ -1,4 +1,5 @@
 import {MongoClient} from 'mongodb'
+import {getCached, setCached} from '../core/cache.js'
 import {} from '../core/env.js'
 
 let client
@@ -26,8 +27,14 @@ export async function upsertOne(name, query, value) {
 }
 
 export async function findAll(name, query, projection) {
+	const cached = getCached(name, query)
+	if (cached) {
+		return cached
+	}
 	const collection = db.collection(name)
-	return await collection.find(query, {projection}).toArray()
+	const result = await collection.find(query, {projection}).toArray()
+	setCached(name, query, result)
+	return result
 }
 
 export async function findOne(name, query, projection) {

--- a/lib/db/query.js
+++ b/lib/db/query.js
@@ -24,19 +24,6 @@ export class SiteQuery {
 	}
 }
 
-export class PageQuery extends SiteQuery {
-	constructor(site, page, days) {
-		super(site, days)
-		this.page = page
-	}
-
-	getQuery() {
-		const query = super.getQuery()
-		query.page = this.page
-		return query
-	}
-}
-
 export function getDay(diff) {
 	const date = new Date()
 	if (diff) {

--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -39,14 +39,6 @@ function buildStats(array) {
 	return stats
 }
 
-export async function readPageStats(query) {
-	if (isDomainHidden(query.site)) {
-		return new Stats()
-	}
-	const array = await findAll('pages', query.getQuery())
-	return buildStats(array)
-}
-
 function readSectionKey(field) {
 	const parts = field.split(':')
 	if (parts.length < 2) {

--- a/lib/server/stats.js
+++ b/lib/server/stats.js
@@ -1,5 +1,5 @@
-import {SiteQuery, PageQuery} from '../db/query.js'
-import {readSiteStats, readPageStats} from '../db/stats.js'
+import {SiteQuery} from '../db/query.js'
+import {readSiteStats} from '../db/stats.js'
 import {createStatsPage} from '../page/stats.js'
 
 const defaultDays = 14
@@ -7,7 +7,6 @@ const defaultDays = 14
 
 export default async function setup(app) {
 	app.get('/:site/siteStats', fetchSiteStats)
-	app.get('/:site/pageStats', fetchPageStats)
 	app.get('/referer/show', showReferer)
 	app.get('/:site/show', show)
 }
@@ -23,20 +22,6 @@ async function fetchSiteStats(request) {
 	const days = request.query.days || defaultDays
 	const query = new SiteQuery(request.params.site, days)
 	return await readSiteStats(query)
-}
-
-/**
- * Request params: site.
- * Query params:
- *	- page: the page to show.
- *	- days: show data only for the latest days, default 30.
- * Response: {ok}.
- * No auth required.
- */
-async function fetchPageStats(request) {
-	const days = request.query.days || defaultDays
-	const query = new PageQuery(request.params.site, days)
-	return await readPageStats(query)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librecounter",
-  "version": "1.0",
+  "version": "2.0",
   "description": "Free and open website statistics",
   "type": "module",
   "main": "index.js",

--- a/test/api.js
+++ b/test/api.js
@@ -54,22 +54,9 @@ async function testLastDays() {
 	console.assert(dayStats.value > 0, 'no value today')
 }
 
-async function testPageStats() {
-	const response = await app.inject({
-		url: `/${site}/pageStats?page=${path}`,
-		method: 'GET',
-		headers: {'user-agent': 'testbot/1.0'},
-	})
-	console.assert(response.statusCode == 200, 'could not get page stats')
-	const result = response.json()
-	console.assert(result.byDay, 'has no days')
-	console.assert(!result.byPage, 'should have no page')
-}
-
 export default async function test() {
 	await testCounter()
 	await testSiteStats()
-	await testPageStats()
 	await testLastDays()
 }
 

--- a/test/api.js
+++ b/test/api.js
@@ -21,42 +21,76 @@ async function testCountPage(page) {
 }
 
 async function testSiteStats() {
+	const stats = await testFetchSiteStats(`/${site}/siteStats`)
+	const day = getDay()
+	const found = stats.byDay.filter(dayStats => dayStats.day == day)
+	console.assert(found.length == 1, 'no data today')
+	console.assert(found[0].value > 0, 'no value today')
+	console.assert(stats.byPage[path], 'has no path')
+}
+
+async function testFetchSiteStats(url) {
 	const response = await app.inject({
-		url: `/${site}/siteStats`,
+		url,
 		method: 'GET',
 		headers: {'user-agent': 'testbot/1.0'},
 	})
 	console.assert(response.statusCode == 200, 'could not stats')
-	const result = response.json()
-	console.assert(result.byDay, 'has no days')
-	console.assert(Array.isArray(result.byDay), 'byDay is not an array')
-	const day = getDay()
-	const found = result.byDay.filter(dayStats => dayStats.day == day)
-	console.assert(found.length == 1, 'no data today')
-	console.assert(found[0].value > 0, 'no value today')
-	console.assert(result.byPage, 'has no pages')
-	console.assert(result.byPage[path], 'has no path')
+	const stats = response.json()
+	console.assert(stats.byDay, 'has no days')
+	console.assert(Array.isArray(stats.byDay), 'byDay is not an array')
+	console.assert(stats.byPage, 'has no pages')
+	return stats
 }
 
 async function testLastDays() {
-	const response = await app.inject({
-		url: `/${site}/siteStats?days=1`,
-		method: 'GET',
-		headers: {'user-agent': 'testbot/1.0'},
-	})
-	console.assert(response.statusCode == 200, 'could not stats')
-	const result = response.json()
-	console.assert(result.byDay, 'has no days')
-	console.assert(result.byDay.length == 1, 'should only have one day')
-	const dayStats = result.byDay[0]
+	const stats = await testFetchSiteStats(`/${site}/siteStats?days=1`)
+	console.assert(stats.byDay.length == 1, 'should only have one day')
+	const dayStats = stats.byDay[0]
 	const day = getDay()
 	console.assert(dayStats.day == day, 'should only have today')
 	console.assert(dayStats.value > 0, 'no value today')
+}
+
+async function testCache() {
+	const cachedPath = '/cached'
+	const day = getDay()
+	const firstStats = await testFetchSiteStats(`/${site}/siteStats`)
+	const firstFound = firstStats.byDay.filter(dayStats => dayStats.day == day)
+	console.assert(firstFound.length == 1, 'no data today')
+	console.assert(firstFound[0].value > 0, 'no value today')
+	const firstPage = firstStats.byPage[cachedPath]
+	console.assert(firstPage, 'has no path')
+	await testCountPage(cachedPath)
+	const secondStats = await testFetchSiteStats(`/${site}/siteStats`)
+	const secondFound = secondStats.byDay.filter(dayStats => dayStats.day == day)
+	console.assert(secondFound.length == 1, 'no data today')
+	console.assert(secondFound[0].value > 0, 'no value today')
+	console.assert(secondStats.byPage[cachedPath], 'has no path')
+	console.assert(secondFound[0].value == firstFound[0].value, 'cached day stats should not increase')
+	const secondPage = secondStats.byPage[cachedPath]
+	console.assert(secondPage == firstPage, 'cached page stats should not increase')
+	await sleep(1001)
+	const thirdStats = await testFetchSiteStats(`/${site}/siteStats`)
+	const thirdFound = thirdStats.byDay.filter(dayStats => dayStats.day == day)
+	console.assert(thirdFound.length == 1, 'no data today')
+	console.assert(thirdFound[0].value > 0, 'no value today')
+	console.assert(thirdFound[0].value == firstFound[0].value + 1, 'expired day stats should increase')
+	const thirdPage = thirdStats.byPage[cachedPath]
+	console.assert(thirdPage == firstPage + 1, 'expired page stats should increase')
+}
+
+/**
+ * Adapted from https://dev.to/codingwithadam/how-to-make-a-sleep-function-in-javascript-with-async-await-499b
+ */
+async function sleep(ms) {
+	return new Promise((resolve) =>setTimeout(resolve, ms))
 }
 
 export default async function test() {
 	await testCounter()
 	await testSiteStats()
 	await testLastDays()
+	await testCache()
 }
 


### PR DESCRIPTION
To improve the response in load peaks, cache all site stats for a second.

Also in this PR:

- Remove `/pageStats` API endpoint, it was not used and also had been broken for a long time.

To be published as v2.0.