### PR TITLE
Fix missing quotation mark in alt attribute in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in all pages that you want analyzed:
 
 ```html
 <a href="https://librecounter.org/referer/show">
-<img src="https://librecounter.org/counter.svg" referrerpolicy="unsafe-url" alt="Logo for librecounter/>
+<img src="https://librecounter.org/counter.svg" referrerpolicy="unsafe-url" alt="Logo for librecounter"/>
 </a>
 ```
 


### PR DESCRIPTION
This commit fixes a small typo in the README file, where a missing quotation mark in the `alt` attribute of the image tag caused incorrect rendering.
