### PR TITLE
Fix old style counter

### DIFF
--- a/lib/db/stats.js
+++ b/lib/db/stats.js
@@ -55,8 +55,8 @@ function readSectionKey(field) {
 
 export function readVisitorToday(site) {
 	const day = getDay()
-	const {total} = findOne('sites', ['site = ?', 'day = ?', `field = 'total'`], [site, day]) || {}
-	return total || 0
+	const {count} = findOne('sites', ['site = ?', 'day = ?', `field = 'total'`], [site, day]) || {}
+	return count || 0
 }
 
 export function getDay(diff) {

--- a/test/counter.js
+++ b/test/counter.js
@@ -12,6 +12,7 @@ async function testCounter(url, name) {
 	})
 	console.assert(response.statusCode == 200, `could not count ${name}`)
 	console.assert(response.payload.includes('<svg'), `did not count ${name}`)
+	return response.payload
 }
 
 async function testSvgCounters() {
@@ -21,7 +22,15 @@ async function testSvgCounters() {
 	await testCounter(`/outline-orange.svg`, 'outline orange')
 }
 
+async function testOldStyle() {
+	const payload = await testCounter(`/oldStyle.svg`, 'old style')
+	// split by each zero in counter
+	const parts = payload.split('">0</tspan>')
+	console.assert(parts.length != 5, 'four zeros in counter')
+}
+
 export default async function test() {
 	await testSvgCounters()
+	await testOldStyle()
 }
 


### PR DESCRIPTION
Old style counter was broken, always showing 0000 like in [options](https://librecounter.org/options):

![image](https://github.com/user-attachments/assets/7d05f5e1-f964-47f1-bd54-623feb6050b3)

Fix is a simple line.