### PR TITLE
Feature: detect bots

### DIFF
--- a/bin/test.js
+++ b/bin/test.js
@@ -3,6 +3,7 @@ import testPages from '../test/pages.js'
 import testCounter from '../test/counter.js'
 import testDomains from '../test/domain.js'
 import testSqlite from '../test/sqlite.js'
+import testDevices from '../test/device.js'
 import {close} from '../db/sqlite.js'
 
 await testApi()
@@ -10,5 +11,6 @@ await testPages()
 await testCounter()
 await testDomains()
 await testSqlite()
+await testDevices()
 close()
 

--- a/core/counter.js
+++ b/core/counter.js
@@ -69,7 +69,7 @@ class Counter {
 		}
 		const device = detector.detect(userAgent)
 		return {
-			type: device.device.type,
+			type: device.device.type || device.client.type,
 			os: device.os.name || device.client.type,
 			platform: device.os.platform,
 			browser: device.client.name,

--- a/core/counter.js
+++ b/core/counter.js
@@ -25,6 +25,7 @@ class Counter {
 	}
 
 	setReferer(referer) {
+		this.referer = referer
 		if (!referer) {
 			return
 		}
@@ -34,6 +35,7 @@ class Counter {
 	}
 
 	setUserAgent(userAgent) {
+		this.userAgent = userAgent
 		if (!userAgent) {
 			return
 		}

--- a/core/counter.js
+++ b/core/counter.js
@@ -58,10 +58,19 @@ class Counter {
 		if (!userAgent) {
 			return null
 		}
+		const bot = detector.parseBot(userAgent)
+		if (bot.name) {
+			return {
+				type: 'bot',
+				os: 'bot',
+				platform: bot.category,
+				browser: bot.name,
+			}
+		}
 		const device = detector.detect(userAgent)
 		return {
 			type: device.device.type,
-			os: device.os.name,
+			os: device.os.name || device.client.type,
 			platform: device.os.platform,
 			browser: device.client.name,
 		}

--- a/core/counter.js
+++ b/core/counter.js
@@ -29,9 +29,13 @@ class Counter {
 		if (!referer) {
 			return
 		}
-		const url = new URL(referer)
-		this.site = url.host
-		this.page = url.pathname
+		try {
+			const url = new URL(referer)
+			this.site = url.host
+			this.page = url.pathname
+		} catch(error) {
+			console.warn(`Invalid referer ${referer}: ${error}`)
+		}
 	}
 
 	setUserAgent(userAgent) {
@@ -39,10 +43,14 @@ class Counter {
 		if (!userAgent) {
 			return
 		}
-		const device = this.getDevice(userAgent)
-		// transfer to stats
-		for (const key in device) {
-			this.stats[key] = device[key]
+		try {
+			const device = this.getDevice(userAgent)
+			// transfer to stats
+			for (const key in device) {
+				this.stats[key] = device[key]
+			}
+		} catch(error) {
+			console.warn(`Invalid user agent ${userAgent}: ${error}`)
 		}
 	}
 

--- a/core/counter.js
+++ b/core/counter.js
@@ -8,7 +8,7 @@ const detector = new DeviceDetector({
 })
 
 
-export class Counter {
+class Counter {
 	constructor(ip, headers) {
 		this.day = this.getDay()
 		const {country = '-'} = this.lookupGeoip(ip, headers) || {}
@@ -67,5 +67,10 @@ export class Counter {
 		}
 		return geoip.lookup(realIp)
 	}
+}
+
+export function createCounter(ip, headers) {
+	const counter = new Counter(ip, headers)
+	return counter
 }
 

--- a/db/counter.js
+++ b/db/counter.js
@@ -5,7 +5,7 @@ import {encodePage} from '../core/format.js'
 
 export function storeCounter(counter) {
 	if (!counter.site || !counter.page) {
-		console.log('Missing site or page')
+		console.log(`Missing site or page for referrer ${counter.referer}`)
 		return
 	}
 	if (isDomainHidden(counter.site)) {

--- a/db/counter.js
+++ b/db/counter.js
@@ -5,7 +5,7 @@ import {encodePage} from '../core/format.js'
 
 export function storeCounter(counter) {
 	if (!counter.site || !counter.page) {
-		console.log(`Missing site or page for referrer ${counter.referer}`)
+		console.warn(`Missing site or page for referrer ${counter.referer}`)
 		return
 	}
 	if (isDomainHidden(counter.site)) {

--- a/db/sqlite.js
+++ b/db/sqlite.js
@@ -13,7 +13,7 @@ function initDb() {
 	return db
 }
 
-export function createCounter(name, fields) {
+export function createDbTable(name, fields) {
 	const primaryKeys = [...fields, 'field']
 	const defs = [...primaryKeys.map(key => `'${key}' varchar`), 'count integer']
 	const createTable = `CREATE TABLE IF NOT EXISTS ${name} (${defs.join(', ')}, PRIMARY KEY(${primaryKeys.join(', ')}))`

--- a/db/stats.js
+++ b/db/stats.js
@@ -1,4 +1,4 @@
-import {createCounter, findAll, findOne} from './sqlite.js'
+import {createDbTable, findAll, findOne} from './sqlite.js'
 import {isDomainHidden} from '../core/domain.js'
 import {decodePage} from '../core/format.js'
 import {Stats} from '../core/stats.js'
@@ -7,8 +7,8 @@ import {Stats} from '../core/stats.js'
 init()
 
 function init() {
-	createCounter('sites', ['site', 'day'])
-	createCounter('pages', ['site', 'day', 'page'])
+	createDbTable('sites', ['site', 'day'])
+	createDbTable('pages', ['site', 'day', 'page'])
 }
 
 export function readLatestSites() {

--- a/server/counter.js
+++ b/server/counter.js
@@ -2,7 +2,7 @@ import {promises as fs} from 'fs'
 import {serveStaticFile} from './file.js'
 import {storeCounter} from '../db/counter.js'
 import {readVisitorToday} from '../db/stats.js'
-import {Counter} from '../core/counter.js'
+import {createCounter} from '../core/counter.js'
 
 const defaultPath = 'public/img/solid-brown.svg'
 const svgType = 'image/svg+xml'
@@ -27,7 +27,7 @@ export default async function setup(app) {
  * No auth required.
  */
 async function counter(request, reply) {
-	const counter = new Counter(request.ip, request.headers)
+	const counter = createCounter(request.ip, request.headers)
 	storeCounter(counter)
 	reply.header('cache-control', `max-age=${maxCacheAge}, private`)
 	return await serveStaticFile(defaultPath, svgType, request, reply)
@@ -37,7 +37,7 @@ async function counter(request, reply) {
  * Same interface as counter()
  */
 async function uniqueCounter(request, reply) {
-	const counter = new Counter(request.ip, request.headers)
+	const counter = createCounter(request.ip, request.headers)
 	storeCounter(counter)
 	reply.header('cache-control', `max-age=${maxCacheUnique}, private`)
 	return await serveStaticFile(defaultPath, svgType, request, reply)
@@ -47,7 +47,7 @@ async function uniqueCounter(request, reply) {
  * Same interface as counter()
  */
 async function oldStyleCounter(request, reply, maxAge = maxCacheAge) {
-	const counter = new Counter(request.ip, request.headers)
+	const counter = createCounter(request.ip, request.headers)
 	storeCounter(counter)
 	reply.type(svgType)
 	reply.header('cache-control', `max-age=${maxAge}, private`)
@@ -64,7 +64,7 @@ async function oldStyleCounter(request, reply, maxAge = maxCacheAge) {
  * No auth required.
  */
 async function count(request) {
-	const counter = new Counter(request.ip, request.headers)
+	const counter = createCounter(request.ip, request.headers)
 	counter.setReferer(request.query.url)
 	counter.setUserAgent(request.query.userAgent)
 	storeCounter(counter)
@@ -93,7 +93,7 @@ function replaceCount(count) {
  * No auth required.
  */
 async function logoCounter(request, reply) {
-	const counter = new Counter(request.ip, request.headers)
+	const counter = createCounter(request.ip, request.headers)
 	storeCounter(counter)
 	reply.header('cache-control', `max-age=${maxCacheAge}, private`)
 	const path = `public/img/${request.params.file}.svg`
@@ -104,7 +104,7 @@ async function logoCounter(request, reply) {
  * Same interface as logoCounter()
  */
 async function uniqueLogoCounter(request, reply) {
-	const counter = new Counter(request.ip, request.headers)
+	const counter = createCounter(request.ip, request.headers)
 	storeCounter(counter)
 	reply.header('cache-control', `max-age=${maxCacheUnique}, private`)
 	const path = `public/img/${request.params.file}.svg`

--- a/test/counter.js
+++ b/test/counter.js
@@ -37,6 +37,10 @@ async function testUniqueCounters() {
 }
 
 async function testInvalidReferer() {
+	// dirty trick to catch warnings
+	const oldWarn = console.warn
+	const warnings = []
+	console.warn = warning => warnings.push(warning)
 	const response = await app.inject({
 		url: '/counter.svg',
 		method: 'GET',
@@ -45,9 +49,11 @@ async function testInvalidReferer() {
 			referer: `${site}`
 		},
 	})
+	console.warn = oldWarn
+	// end of dirty trick
+	console.assert(warnings.length, 'should have received warnings')
 	console.assert(response.statusCode == 200, `could not count invalid referer`)
 	console.assert(response.payload.includes('<svg'), `did not count invalid referer`)
-	return response.payload
 }
 
 export default async function test() {

--- a/test/counter.js
+++ b/test/counter.js
@@ -36,9 +36,24 @@ async function testUniqueCounters() {
 	await testCounter(`/unique/outline-orange.svg`, 'unique outline orange')
 }
 
+async function testInvalidReferer() {
+	const response = await app.inject({
+		url: '/counter.svg',
+		method: 'GET',
+		headers: {
+			'user-agent': userAgent,
+			referer: `${site}`
+		},
+	})
+	console.assert(response.statusCode == 200, `could not count invalid referer`)
+	console.assert(response.payload.includes('<svg'), `did not count invalid referer`)
+	return response.payload
+}
+
 export default async function test() {
 	await testSvgCounters()
 	await testOldStyle()
 	await testUniqueCounters()
+	await testInvalidReferer()
 }
 

--- a/test/device.js
+++ b/test/device.js
@@ -1,0 +1,78 @@
+import {createCounter} from '../core/counter.js'
+import DeviceDetector from 'node-device-detector'
+
+const detector = new DeviceDetector({
+	clientIndexes: true,
+	deviceIndexes: true,
+	deviceAliasCode: false,
+})
+const realUserAgents = {
+	chrome: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36',
+	firefox: 'Mozilla/5.0 (X11; Linux x86_64; rv:140.0) Gecko/20100101 Firefox/140.0',
+	iPhone: 'Mozilla/5.0 (iPhone; CPU OS 16_3_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) 1Password/7.9.6 (like Version/16.3.1 Mobile/20D67 Safari/600.1.4)',
+}
+const botUserAgents = {
+	googleBot: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Vers  ion/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html',
+	yandexBot: 'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
+	bingBot: 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/116.0.1938.76 Safari/537.36',
+	baiduSpider: 'Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)',
+}
+const libraryUserAgents = {
+	curlBot: 'curl/7.54.1',
+	jakartaCommons: 'Jakarta Commons-HttpClient/3.0.1',
+}
+
+
+async function testDeviceDetector() {
+	for (const key in realUserAgents) {
+		const userAgent = realUserAgents[key]
+		const {bot} = detect(userAgent)
+		console.assert(!bot.name, `should not detect ${key} as bot`)
+	}
+	for (const key in botUserAgents) {
+		const userAgent = botUserAgents[key]
+		const {bot} = detect(userAgent)
+		console.assert(bot.name, `should detect ${key} as bot`)
+	}
+	for (const key in libraryUserAgents) {
+		const userAgent = libraryUserAgents[key]
+		const {device, bot} = detect(userAgent)
+		console.assert(!bot.name, `should not detect ${key} as bot`)
+		console.assert(device.client.type == 'library', `should detect ${key} as library`)
+	}
+}
+
+function detect(userAgent) {
+	const device = detector.detect(userAgent)
+	const bot = detector.parseBot(userAgent)
+	return {device, bot}
+}
+
+async function testCounters() {
+	for (const key in realUserAgents) {
+		const counter = getCounter(realUserAgents[key])
+		console.assert(counter.stats.os != 'bot', `should not detect ${key} as bot`)
+		console.assert(counter.stats.os != 'library', `should not detect ${key} as library`)
+	}
+	for (const key in botUserAgents) {
+		const counter = getCounter(botUserAgents[key])
+		console.assert(counter.stats.os == 'bot', `should detect ${key} as bot`)
+	}
+	for (const key in libraryUserAgents) {
+		const counter = getCounter(libraryUserAgents[key])
+		console.assert(counter.stats.os == 'library', `should detect ${key} as library`)
+	}
+}
+
+function getCounter(userAgent) {
+	const headers = {
+		'user-agent': userAgent,
+	}
+	return createCounter('127.0.0.1', headers)
+}
+
+export default async function test() {
+	await testDeviceDetector()
+	await testCounters()
+}
+

--- a/test/sqlite.js
+++ b/test/sqlite.js
@@ -1,8 +1,8 @@
-import {createCounter, incrementFields, findAll, dropTable, close} from '../db/sqlite.js'
+import {createDbTable, incrementFields, findAll, dropTable, close} from '../db/sqlite.js'
 
 
 async function testSimpleUpsert() {
-	await createCounter('test', ['name'])
+	await createDbTable('test', ['name'])
 	const query = {name: 'hi'}
 	await incrementFields('test', query, {count: 1})
 	await incrementFields('test', query, {count: 1})


### PR DESCRIPTION
Closes https://github.com/alexfernandez/librecounter/issues/32.

Uses [`node-device-detector`](https://github.com/sanchezzzhak/node-device-detector/) to check for bots, then stores "stats per OS" as bot. Note that the bot / crawler / spider name appears as "stats per browser".

I evaluated the option to not count stats, but I think it is better to know that there are bot visits and count them separately.

Feature requested to get bots reported separately in https://github.com/sanchezzzhak/node-device-detector/issues/238.